### PR TITLE
Revert common_msgs renames

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/status_item.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/status_item.h
@@ -71,9 +71,9 @@ inline std::string getOutputName(const std::string item_name)
  */
 enum DiagnosticLevel
 {
-  Level_OK = diagnostic_msgs::DiagnosticStatus::DIAG_OK,
-  Level_Warn = diagnostic_msgs::DiagnosticStatus::DIAG_WARN,
-  Level_Error = diagnostic_msgs::DiagnosticStatus::DIAG_ERROR,
+  Level_OK = diagnostic_msgs::DiagnosticStatus::OK,
+  Level_Warn = diagnostic_msgs::DiagnosticStatus::WARN,
+  Level_Error = diagnostic_msgs::DiagnosticStatus::ERROR,
   Level_Stale = 3
 };
 
@@ -82,11 +82,11 @@ enum DiagnosticLevel
  */
 inline DiagnosticLevel valToLevel(const int val)
 {
-  if (val == diagnostic_msgs::DiagnosticStatus::DIAG_OK)
+  if (val == diagnostic_msgs::DiagnosticStatus::OK)
     return Level_OK;
-  if (val == diagnostic_msgs::DiagnosticStatus::DIAG_WARN)
+  if (val == diagnostic_msgs::DiagnosticStatus::WARN)
     return Level_Warn;
-  if (val == diagnostic_msgs::DiagnosticStatus::DIAG_ERROR)
+  if (val == diagnostic_msgs::DiagnosticStatus::ERROR)
     return Level_Error;
   if (val == 3)
     return Level_Stale;
@@ -100,11 +100,11 @@ inline DiagnosticLevel valToLevel(const int val)
  */
 inline std::string valToMsg(const int val)
 {
-  if (val == diagnostic_msgs::DiagnosticStatus::DIAG_OK)
+  if (val == diagnostic_msgs::DiagnosticStatus::OK)
     return "OK";
-  if (val == diagnostic_msgs::DiagnosticStatus::DIAG_WARN)
+  if (val == diagnostic_msgs::DiagnosticStatus::WARN)
     return "Warning";
-  if (val == diagnostic_msgs::DiagnosticStatus::DIAG_ERROR)
+  if (val == diagnostic_msgs::DiagnosticStatus::ERROR)
     return "Error";
   if (val == 3)
     return "Stale";

--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -35,6 +35,9 @@
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <std_msgs/Bool.h>
 #include <diagnostic_updater/publisher.h>
+#ifdef ERROR
+#undef ERROR
+#endif
 
 double time_to_launch;
 

--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -54,10 +54,10 @@ void dummy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
   // summary and summaryf set the level and message.
   if (time_to_launch < 10)
     // summaryf for formatted text.
-    stat.summaryf(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "Buckle your seat belt. Launch in %f seconds!", time_to_launch);
+    stat.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR, "Buckle your seat belt. Launch in %f seconds!", time_to_launch);
   else
     // summary for unformatted text.
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Launch is in a long time. Have a soda.");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Launch is in a long time. Have a soda.");
 
   // add and addf are used to append key-value pairs.
   stat.add("Diagnostic Name", "dummy");
@@ -73,7 +73,7 @@ class DummyClass
 public:
   void produce_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_WARN, "This is a silly updater.");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "This is a silly updater.");
 
     stat.add("Stupidicity of this updater", 1000.);
   }
@@ -87,7 +87,7 @@ public:
 
   void run(diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_WARN, "This is another silly updater.");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "This is another silly updater.");
     stat.add("Stupidicity of this updater", 2000.);
   }
 };
@@ -95,9 +95,9 @@ public:
 void check_lower_bound(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {
   if (time_to_launch > 5)
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Lower-bound OK");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Lower-bound OK");
   else
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "Too low");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "Too low");
 
   stat.add("Low-Side Margin", time_to_launch - 5);
 }
@@ -105,9 +105,9 @@ void check_lower_bound(diagnostic_updater::DiagnosticStatusWrapper &stat)
 void check_upper_bound(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {
   if (time_to_launch < 10)
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Upper-bound OK");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Upper-bound OK");
   else
-    stat.summary(diagnostic_msgs::DiagnosticStatus::DIAG_WARN, "Too high");
+    stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "Too high");
 
   stat.add("Top-Side Margin", 10 - time_to_launch);
 }

--- a/self_test/src/selftest_example.cpp
+++ b/self_test/src/selftest_example.cpp
@@ -85,7 +85,7 @@ public:
   void pretest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing preparation stuff before we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Pretest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Pretest completed successfully.");
     
     some_val = 1.0;
   }
@@ -103,7 +103,7 @@ public:
 
     if (lookup_successful)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "ID Lookup successful");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "ID Lookup successful");
       
       // One of the tests should call setID() to fill the hardware
       // identifier in the self-test output. In cases that do not involve
@@ -114,7 +114,7 @@ public:
       self_test_.setID(ID);
 
     } else {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "ID Lookup failed");
+      status.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "ID Lookup failed");
     }
   }
 
@@ -133,7 +133,7 @@ public:
     throw std::runtime_error("we did something that threw an exception");
 
     // Here's where we would report success if we'd made it past
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We made it past the exception throwing statement.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We made it past the exception throwing statement.");
   }
 
   // The state of the node can be changed as the tests are operating
@@ -143,25 +143,25 @@ public:
     some_val += 41.0;
 
     status.add("some value", some_val);
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We successfully changed the value.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We successfully changed the value.");
   }
 
   void test4(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     if (some_val == 42.0)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We observed the change in value");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We observed the change in value");
     } 
     else
     {
-      status.summaryf(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
+      status.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
     }
   }
 
   void posttest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing cleanup stuff after we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Posttest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Posttest completed successfully.");
   }
 
   bool spin()

--- a/self_test/test/error_selftest.cpp
+++ b/self_test/test/error_selftest.cpp
@@ -65,7 +65,7 @@ public:
   void pretest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing preparation stuff before we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Pretest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Pretest completed successfully.");
     
     some_val = 1.0;
   }
@@ -78,17 +78,17 @@ public:
 
     if (lookup_successful)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "ID Lookup successful");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "ID Lookup successful");
       self_test_.setID(ID);
     } 
     else 
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "ID Lookup failed");
+      status.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "ID Lookup failed");
   }
 
   void test2(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     // Report an error, this should fail self test
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "Reporting an error");
+    status.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "Reporting an error");
   }
 
   void test3(diagnostic_updater::DiagnosticStatusWrapper& status)
@@ -96,25 +96,25 @@ public:
     some_val += 41.0;
 
     status.add("some value", some_val);
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We successfully changed the value.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We successfully changed the value.");
   }
 
   void test4(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     if (some_val == 42.0)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We observed the change in value");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We observed the change in value");
     } 
     else
     {
-      status.summaryf(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
+      status.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
     }
   }
 
   void posttest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing cleanup stuff after we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Posttest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Posttest completed successfully.");
   }
 
   bool spin()

--- a/self_test/test/exception_selftest.cpp
+++ b/self_test/test/exception_selftest.cpp
@@ -69,7 +69,7 @@ public:
   void pretest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing preparation stuff before we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Pretest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Pretest completed successfully.");
     
     some_val = 1.0;
   }
@@ -82,12 +82,12 @@ public:
 
     if (lookup_successful)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "ID Lookup successful");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "ID Lookup successful");
       
       self_test_.setID(ID);
 
     } else {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "ID Lookup failed");
+      status.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "ID Lookup failed");
     }
   }
 
@@ -99,7 +99,7 @@ public:
     throw std::runtime_error("we did something that threw an exception");
 
     // Here's where we would report success if we'd made it past
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We made it past the exception throwing statement.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We made it past the exception throwing statement.");
   }
 
   void test3(diagnostic_updater::DiagnosticStatusWrapper& status)
@@ -107,25 +107,25 @@ public:
     some_val += 41.0;
 
     status.add("some value", some_val);
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We successfully changed the value.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We successfully changed the value.");
   }
 
   void test4(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     if (some_val == 42.0)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We observed the change in value");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We observed the change in value");
     } 
     else
     {
-      status.summaryf(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
+      status.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
     }
   }
 
   void posttest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing cleanup stuff after we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Posttest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Posttest completed successfully.");
   }
 
   bool spin()

--- a/self_test/test/no_id_selftest.cpp
+++ b/self_test/test/no_id_selftest.cpp
@@ -66,14 +66,14 @@ public:
   void pretest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing preparation stuff before we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Pretest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Pretest completed successfully.");
     
     some_val = 1.0;
   }
 
   void test1(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "ID not set");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "ID not set");
   }
 
   void test3(diagnostic_updater::DiagnosticStatusWrapper& status)
@@ -81,25 +81,25 @@ public:
     some_val += 41.0;
 
     status.add("some value", some_val);
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We successfully changed the value.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We successfully changed the value.");
   }
 
   void test4(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     if (some_val == 42.0)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We observed the change in value");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We observed the change in value");
     } 
     else
     {
-      status.summaryf(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
+      status.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
     }
   }
 
   void posttest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing cleanup stuff after we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Posttest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Posttest completed successfully.");
   }
 
   bool spin()

--- a/self_test/test/nominal_selftest.cpp
+++ b/self_test/test/nominal_selftest.cpp
@@ -65,7 +65,7 @@ public:
   void pretest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing preparation stuff before we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Pretest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Pretest completed successfully.");
     
     some_val = 1.0;
   }
@@ -78,12 +78,12 @@ public:
 
     if (lookup_successful)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "ID Lookup successful");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "ID Lookup successful");
       
       self_test_.setID(ID);
 
     } else {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "ID Lookup failed");
+      status.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "ID Lookup failed");
     }
   }
 
@@ -93,7 +93,7 @@ public:
     status.level = 0;
 
     // Here's where we would report success if we'd made it past
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We made it past the exception throwing statement.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We made it past the exception throwing statement.");
   }
 
   void test3(diagnostic_updater::DiagnosticStatusWrapper& status)
@@ -101,25 +101,25 @@ public:
     some_val += 41.0;
 
     status.add("some value", some_val);
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We successfully changed the value.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We successfully changed the value.");
   }
 
   void test4(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     if (some_val == 42.0)
     {
-      status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "We observed the change in value");
+      status.summary(diagnostic_msgs::DiagnosticStatus::OK, "We observed the change in value");
     } 
     else
     {
-      status.summaryf(diagnostic_msgs::DiagnosticStatus::DIAG_ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
+      status.summaryf(diagnostic_msgs::DiagnosticStatus::ERROR, "We failed to observe the change in value, it is currently %f.", some_val);
     }
   }
 
   void posttest(diagnostic_updater::DiagnosticStatusWrapper& status)
   {
     ROS_INFO("Doing cleanup stuff after we run our test.\n");
-    status.summary(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Posttest completed successfully.");
+    status.summary(diagnostic_msgs::DiagnosticStatus::OK, "Posttest completed successfully.");
   }
 
   bool spin()


### PR DESCRIPTION
This is part of a fix for https://github.com/ms-iot/ROSOnWindows/issues/34

* Revert common_msgs renames.
* Add a workaround in example.cpp for ERROR macro define from Windows.h, which gets included by ros\io.h (via winsock2.h)